### PR TITLE
added support for DOM node appends

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,41 @@
 export default function h(strings, ...args) {
-  let result = ``; 
-  for(let i = 0; i < args.length; i++) result += strings[i] + args[i]
-  result += strings[strings.length - 1]
+  let result = ``;
+  const appends = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] instanceof HTMLElement) {
+      const id = 'id' + i;
+      appends[id] = args[i];
+      result += `${strings[i]}<div append="${id}"></div>`;
+    } else {
+      result += strings[i] + args[i];
+    }
+  }
+  result += strings[strings.length - 1];
 
   const template = document.createElement(`template`);
   template.innerHTML = result;
 
   const content = template.content;
 
-  content.collect = ({attr = 'ref', keepAttribute, to = {}} = {}) => {
+  [...content.querySelectorAll(`[append]`)].forEach(refNode => {
+    const newNode = appends[refNode.getAttribute('append')];
+    refNode.parentNode.insertBefore(newNode, refNode);
+    refNode.parentNode.removeChild(refNode);
+  });
+
+  content.collect = ({ attr = 'ref', keepAttribute, to = {} } = {}) => {
     const refElements = content.querySelectorAll(`[${attr}]`);
     return [...refElements].reduce((acc, element) => {
       const propName = element.getAttribute(attr).trim();
-      !keepAttribute && (element.removeAttribute(attr));
+      !keepAttribute && element.removeAttribute(attr);
       acc[propName] = acc[propName]
-      ? Array.isArray(acc[propName])
-        ? [...acc[propName], element]
-        : [acc[propName], element]
-      : element;
-    return acc;
+        ? Array.isArray(acc[propName])
+          ? [...acc[propName], element]
+          : [acc[propName], element]
+        : element;
+      return acc;
     }, to);
-  }
+  };
 
   return content;
 }


### PR DESCRIPTION
Adds supports for appending DOM nodes from javascript.

```
let myNode = document.createElement('div');
let node = f`<div>${myNode}</div>;
```
or
```
let myNode = f`<b>Hello World</b>;
let node = f`<div>${myNode}</div>;
```
