### PR TITLE
Golf a bit (424 -> 365b gzipped)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,10 @@
 export default function h(strings, ...args) {
   const template = document.createElement(`template`);
 
-  template.innerHTML = args.reduce((prev, value, i) => {
-    return prev +
-      (value instanceof HTMLElement ? `<b append=${i}></b>` : value) +
-      strings[i + 1]
-  }, strings[0]);
+  template.innerHTML = args.reduce((prev, value, i) =>
+    prev + (value instanceof HTMLElement ? `<b append=${i}></b>` : value) + strings[i + 1],
+    strings[0]
+  );
 
   const content = template.content;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,16 @@
 export default function h(strings, ...args) {
-  let result = ``;
-  const appends = {};
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] instanceof HTMLElement) {
-      const id = `id${i}`;
-      appends[id] = args[i];
-      result += `${strings[i]}<div append="${id}"></div>`;
-    } else {
-      result += strings[i] + args[i];
-    }
-  }
-  result += strings[strings.length - 1];
-
   const template = document.createElement(`template`);
-  template.innerHTML = result;
+
+  template.innerHTML = args.reduce((prev, value, i) => {
+    return prev +
+      (value instanceof HTMLElement ? `<b append=${i}></b>` : value) +
+      strings[i + 1]
+  }, strings[0]);
 
   const content = template.content;
 
   [...content.querySelectorAll(`[append]`)].forEach(refNode => {
-    const newNode = appends[refNode.getAttribute('append')];
-    refNode.parentNode.insertBefore(newNode, refNode);
+    refNode.parentNode.insertBefore(args[refNode.getAttribute('append')], refNode);
     refNode.parentNode.removeChild(refNode);
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export default function h(strings, ...args) {
 
   const content = template.content;
 
-  [...content.querySelectorAll(`[append]`)].forEach(refNode => {
+  content.querySelectorAll(`[append]`).forEach(refNode => {
     refNode.parentNode.insertBefore(args[refNode.getAttribute('append')], refNode);
     refNode.parentNode.removeChild(refNode);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,11 @@ test('facon: standard', async t => {
   t.is(typeof f, 'function', 'constructor is a typeof function');
 });
 
+test('facon: empty string', async t => {
+  t.plan(1);
+  t.is(s(f``), '');
+});
+
 test('facon: build element', async t => {
   t.plan(4);
   t.is(s(f`hello`), 'hello');

--- a/test/index.js
+++ b/test/index.js
@@ -19,9 +19,14 @@ test('facon: standard', async t => {
   t.is(typeof f, 'function', 'constructor is a typeof function');
 });
 
-test('facon: empty string', async t => {
-  t.plan(1);
-  t.is(s(f``), '');
+test('facon: awkward boundary conditions', async t => {
+  t.plan(5);
+  let subst = 100;
+  t.is(s(f``), '', 'empty string');
+  t.is(s(f`${subst}`), '100', 'just arg');
+  t.is(s(f`${subst}left`), '100left', 'arg on far left');
+  t.is(s(f`right${subst}`), 'right100', 'arg on far right');
+  t.is(s(f`${subst}mid${subst}`), '100mid100', 'args on either end')
 });
 
 test('facon: build element', async t => {


### PR DESCRIPTION
Hi! Fun library! I took it apart to see how it works (I'm new to Javascript) and ended up putting it back together in fewer pieces than I started with, so figured i'd upstream what i got.

This brings the library from 824 -> 715 bytes minified and 424 -> 365 bytes gzipped (well, counting the gzipped size before the UMD header is added, as the buildscript does). I can't replicate these 272b/295b figures on the readme, guessing they may be outdated from before `collect` was added. Note that this will conflict with #7 since it messes with the loop that PR adds a side-effect to, and ultra-microoptimizing the size of the library to this degree might not be your priority..... just writing this in good fun 🐲

* Instead of writing `append="id0"` to the element I just write `append="0"`. This allows me to delete the `appends` table entirely, since i can conveniently index into `args`.
* I inlined `const newNode` because for some reason Terser wasn't.
* I removed a spread operator used on `content.querySelectorAll` since I don't *think* it was necessary but im not super familiar with the ins and outs of why the spread operator was used here.
* The string concatenation loop is rebracketed - rather than looping over `strings[i]` and `args[i]` then special-casing `strings[strings.length-1]`, I special-case `strings[0]` then loop over `args[i]` and `strings[i+1]`
  * Added a test for ``` f`` ``` because of this, and threw in a few other edge-case tests too
* Ended up phrasing that loop with a `reduce` actually, which mostly just makes a mess of things, I tried a `map` but it was larger, and i think a `for(let [i, value] in args.entries()) result += ...` loop is clearer, but this minifies the best 🤷 